### PR TITLE
Add minimal test coverage for K256 and Ed25519 key types

### DIFF
--- a/key.go
+++ b/key.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/multiformats/go-multibase"
 	"github.com/multiformats/go-varint"
-
-	"github.com/ipsn/go-secp256k1"
 	secp "github.com/ipsn/go-secp256k1"
 )
 
@@ -134,7 +132,7 @@ func (k *PubKey) MultibaseString() string {
 
 		buf = varEncode(MCP256, kb)
 	case KeyTypeSecp256k1:
-		kb, err := convertToCompressed(secp256k1.S256(), k.Raw.([]byte))
+		kb, err := convertToCompressed(secp.S256(), k.Raw.([]byte))
 		if err != nil {
 			return "<invalid key>"
 		}

--- a/key_test.go
+++ b/key_test.go
@@ -3,12 +3,15 @@ package did
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/ed25519"
 	"crypto/rand"
 	"fmt"
 	"testing"
+
+	"github.com/ipsn/go-secp256k1"
 )
 
-func TestKeySignVerify(t *testing.T) {
+func TestKeySignVerifyP256(t *testing.T) {
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -16,6 +19,61 @@ func TestKeySignVerify(t *testing.T) {
 
 	sk := &PrivKey{
 		Type: KeyTypeP256,
+		Raw:  k,
+	}
+
+	msg := []byte("foo bar beep boop bop")
+
+	sig, err := sk.Sign(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(sig)
+
+	if err := sk.Public().Verify(msg, sig); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKeySignVerifyK256(t *testing.T) {
+	k, err := ecdsa.GenerateKey(secp256k1.S256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// this bit copied from upstream go-secp256k1 tests
+	privkey := make([]byte, 32)
+	blob := k.D.Bytes()
+	copy(privkey[32-len(blob):], blob)
+
+	sk := &PrivKey{
+		Type: KeyTypeSecp256k1,
+		Raw:  privkey,
+	}
+
+	msg := []byte("foo bar beep boop bop")
+
+	sig, err := sk.Sign(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(sig)
+
+	if err := sk.Public().Verify(msg, sig); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKeySignVerifyEd25519(t *testing.T) {
+	_, k, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sk := &PrivKey{
+		Type: KeyTypeEd25519,
 		Raw:  k,
 	}
 


### PR DESCRIPTION
The K256 test is currently failing. Not sure what i'm doing wrong; maybe generating the keypair incorrectly?

Additional test for, eg, parsing did-formatted keys from known strings, would be good.