### PR TITLE
Fix build of example apps and generalize signing

### DIFF
--- a/cmd/didcli/main.go
+++ b/cmd/didcli/main.go
@@ -66,8 +66,8 @@ var registerCmd = &cli.Command{
 		body := &RegisterBody{
 			InitialKey: id,
 			InitialVerification: did.VerificationMethod{
-				ID:   id,
-				Type: "JsonWebKey2020",
+				ID:   id.String(),
+				Type: did.KeyTypeEd25519,
 				//Controller         string        `json:"controller"`
 				PublicKeyJwk: &did.PublicKeyJwk{j},
 			},
@@ -108,7 +108,7 @@ var registerCmd = &cli.Command{
 	},
 }
 
-func loadKey(keyfi string) (ed25519.PrivateKey, error) {
+func loadKey(keyfi string) (*did.PrivKey, error) {
 	data, err := ioutil.ReadFile(keyfi)
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func loadKey(keyfi string) (ed25519.PrivateKey, error) {
 	}
 
 	k := ed25519.NewKeyFromSeed(kb)
-	return k, nil
+	return &did.PrivKey{Raw: k, Type: did.KeyTypeEd25519}, nil
 }
 
 func writeDocument(doc did.Document, fname string) error {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -49,14 +48,14 @@ func (s *Server) handleGetDocument(c echo.Context) error {
 	return c.JSON(200, doc)
 }
 
-func (s *Server) pubkeyForID(id did.DID) (ed25519.PublicKey, error) {
+func (s *Server) pubkeyForID(id did.DID) (*did.PubKey, error) {
 	doc, ok := s.getDocument(id)
 	if !ok {
 		return nil, fmt.Errorf("no registered account for that did")
 	}
 
 	// TODO: support more than one verification method
-	return doc.Document.GetPublicKey()
+	return doc.Document.GetPublicKey("")
 }
 
 func (s *Server) updateDocument(id did.DID, doc *did.SignedDocument) error {

--- a/did.go
+++ b/did.go
@@ -76,7 +76,7 @@ type Service struct {
 
 type VerificationMethod struct {
 	ID                 string        `json:"id"`
-	Type               string        `json:"type"`
+	Type               KeyType       `json:"type"`
 	Controller         string        `json:"controller"`
 	PublicKeyJwk       *PublicKeyJwk `json:"publicKeyJwk,omitempty"`
 	PublicKeyMultibase *string       `json:"publicKeyMultibase,omitempty"`
@@ -95,7 +95,7 @@ func (vm VerificationMethod) GetPublicKey() (*PubKey, error) {
 		}
 
 		return &PubKey{
-			Type: "ed25519",
+			Type: KeyTypeEd25519,
 			Raw:  []byte(ek),
 		}, nil
 	}

--- a/key.go
+++ b/key.go
@@ -22,15 +22,30 @@ const (
 	MCP256      = 0x1200
 	MCSecp256k1 = 0xe7
 )
+
+type KeyType int
+
+func (kt KeyType) String() string {
+	switch kt {
+	case KeyTypeSecp256k1:
+		return "EcdsaSecp256k1VerificationKey2019"
+	case KeyTypeP256:
+		return "EcdsaSecp256r1VerificationKey2019"
+	case KeyTypeEd25519:
+		return "Ed25519VerificationKey2020"		
+	}
+	return "unknown key type"
+}
+
 const (
-	KeyTypeSecp256k1 = "EcdsaSecp256k1VerificationKey2019"
-	KeyTypeP256      = "EcdsaSecp256r1VerificationKey2019"
-	KeyTypeEd25519   = "Ed25519VerificationKey2020"
+	KeyTypeSecp256k1 KeyType = iota
+	KeyTypeP256      
+	KeyTypeEd25519   
 )
 
 type PrivKey struct {
-	Raw  interface{}
-	Type string
+	Raw  any
+	Type KeyType
 }
 
 func (k *PrivKey) Public() *PubKey {
@@ -90,7 +105,7 @@ func (k *PrivKey) Sign(b []byte) ([]byte, error) {
 	}
 }
 
-func (k *PrivKey) KeyType() string {
+func (k *PrivKey) KeyType() KeyType {
 	return k.Type
 }
 
@@ -105,7 +120,7 @@ func varEncode(pref uint64, body []byte) []byte {
 
 type PubKey struct {
 	Raw  any
-	Type string
+	Type KeyType
 }
 
 func (k *PubKey) DID() string {


### PR DESCRIPTION
introduce KeyType instead of a string
fix build of cli and server
SignDocument and VerifyDocumentSignature no longer care about underlying type

Im not sure I set the key types correctly in the cli. @whyrusleeping do you mind checking?