### PR TITLE
need to properly pack p256 signature values into the output buffer

### DIFF
--- a/key.go
+++ b/key.go
@@ -77,8 +77,10 @@ func (k *PrivKey) Sign(b []byte) ([]byte, error) {
 		}
 
 		out := make([]byte, 64)
-		copy(out[:32], r.Bytes())
-		copy(out[32:], s.Bytes())
+		rb := r.Bytes()
+		sb := s.Bytes()
+		copy(out[32-len(rb):32], rb)
+		copy(out[32+(32-len(sb)):], sb)
 
 		return out, nil
 	case KeyTypeSecp256k1:

--- a/key_test.go
+++ b/key_test.go
@@ -6,6 +6,9 @@ import (
 	"crypto/rand"
 	"fmt"
 	"testing"
+
+	secp "github.com/ipsn/go-secp256k1"
+	"github.com/multiformats/go-multibase"
 )
 
 func TestKeySignVerify(t *testing.T) {
@@ -21,14 +24,77 @@ func TestKeySignVerify(t *testing.T) {
 
 	msg := []byte("foo bar beep boop bop")
 
+	for i := 0; i < 5000; i++ {
+		sig, err := sk.Sign(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		enc, err := multibase.Encode(multibase.Base58BTC, sk.Public().Raw.([]byte))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rpk, err := KeyFromMultibase(VerificationMethod{
+			ID:                 "#atproto",
+			Type:               "EcdsaSecp256r1VerificationKey2019",
+			PublicKeyMultibase: &enc,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fmt.Println(sig)
+		if err := rpk.Verify(msg, sig); err != nil {
+			t.Fatalf("iteration %d: %s", i, err)
+		}
+	}
+}
+
+func TestKeySignVerifySecp(t *testing.T) {
+	t.Skip()
+	k, err := ecdsa.GenerateKey(secp.S256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privkey := make([]byte, 32)
+	blob := k.D.Bytes()
+	copy(privkey[32-len(blob):], blob)
+
+	pubkey := elliptic.Marshal(secp.S256(), k.X, k.Y)
+
+	fmt.Printf("PUBKEY: %x\n", pubkey)
+
+	sk := &PrivKey{
+		Type: KeyTypeSecp256k1,
+		Raw:  privkey,
+	}
+
+	msg := []byte("foo bar beep boop bop")
+
 	sig, err := sk.Sign(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mbs := sk.Public().MultibaseString()
+	fmt.Println("MULTIBASE: ", mbs)
+
+	rpk, err := KeyFromMultibase(VerificationMethod{
+		ID:                 "#atproto",
+		Type:               KeyTypeSecp256k1,
+		PublicKeyMultibase: &mbs,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	fmt.Println(sig)
 
-	if err := sk.Public().Verify(msg, sig); err != nil {
+	fmt.Printf("RPK: %x\n", rpk.Raw)
+
+	if err := rpk.Verify(msg, sig); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
The issue was that very occasionally `len(r.Bytes())` is only 31