### PR TITLE
DID Document Iteration

### DIFF
--- a/did.go
+++ b/did.go
@@ -149,6 +149,15 @@ func (vm *VerificationMethod) GetPublicKey() (*PubKey, error) {
 		return pk, nil
 	}
 
+	if vm.Type == KeyTypeMultikey && vm.PublicKeyMultibase != nil {
+		pk, err := PubKeyFromMultibaseString(*vm.PublicKeyMultibase)
+		if err != nil {
+			return nil, err
+		}
+		vm.setKey(pk)
+		return pk, nil
+	}
+
 	if vm.PublicKeyMultibase != nil {
 		_, data, err := multibase.Decode(*vm.PublicKeyMultibase)
 		if err != nil {
@@ -225,7 +234,7 @@ func (pk *PublicKeyJwk) GetRawKey() (interface{}, error) {
 
 func (d *Document) GetPublicKey(id string) (*PubKey, error) {
 	for _, vm := range d.VerificationMethod {
-		if id == vm.ID || id == "" {
+		if id == "" || id == vm.ID || (strings.HasPrefix(id, "#") && (d.ID.String()+id == vm.ID)) {
 			return vm.GetPublicKey()
 		}
 	}

--- a/did.go
+++ b/did.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/multiformats/go-multibase"
 )
 
 const (
@@ -149,7 +150,12 @@ func (vm *VerificationMethod) GetPublicKey() (*PubKey, error) {
 	}
 
 	if vm.PublicKeyMultibase != nil {
-		k, err := PubKeyFromMultibaseString(*vm.PublicKeyMultibase)
+		_, data, err := multibase.Decode(*vm.PublicKeyMultibase)
+		if err != nil {
+			return nil, err
+		}
+
+		k, err := keyDataAndTypeToKey(vm.Type, data)
 		if err != nil {
 			return nil, err
 		}
@@ -225,4 +231,19 @@ func (d *Document) GetPublicKey(id string) (*PubKey, error) {
 	}
 
 	return nil, fmt.Errorf("no key found by that ID")
+}
+
+func VerificationMethodFromKey(k *PubKey) (*VerificationMethod, error) {
+
+	kb := k.rawBytes()
+	if kb == nil {
+		return nil, fmt.Errorf("unrecognized key type")
+	}
+
+	enc, _ := multibase.Encode(multibase.Base58BTC, kb)
+
+	return &VerificationMethod{
+		Type:               k.Type,
+		PublicKeyMultibase: &enc,
+	}, nil
 }

--- a/did_test.go
+++ b/did_test.go
@@ -1,0 +1,61 @@
+package did
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestDidDoc(t *testing.T) {
+	testPaths := []string{
+		"testdata/did_doc_legacy.json",
+		"testdata/did_doc_multikey.json",
+	}
+	for _, path := range testPaths {
+		f, err := os.Open(path)
+		if err != nil {
+			t.Error(err)
+		}
+		defer f.Close()
+		fBytes, err := io.ReadAll(f)
+		if err != nil {
+			t.Error(err)
+		}
+
+		var doc Document
+		if err := json.Unmarshal(fBytes, &doc); err != nil {
+			t.Error(err)
+		}
+
+		pk, err := doc.GetPublicKey("#atproto")
+		if err != nil {
+			t.Error(err)
+		}
+
+		if pk.DID() != "did:key:zQ3shXjHeiBuRCKmM36cuYnm7YEMzhGnCmCyW92sRJ9pribSF" {
+			fmt.Println(pk.DID())
+			t.Error("didn't export key as expected")
+		}
+	}
+}
+
+func TestSig(t *testing.T) {
+	vmstr := `{
+      "id": "#atproto",
+      "type": "EcdsaSecp256k1VerificationKey2019",
+      "controller": "did:plc:wj5jny4sq4sohwoaxjkjgug6",
+      "publicKeyMultibase": "zQYEBzXeuTM9UR3rfvNag6L3RNAs5pQZyYPsomTsgQhsxLdEgCrPTLgFna8yqCnxPpNT7DBk6Ym3dgPKNu86vt9GR"
+    }`
+	var vm VerificationMethod
+
+	if err := json.Unmarshal([]byte(vmstr), &vm); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := vm.GetPublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/key.go
+++ b/key.go
@@ -233,24 +233,11 @@ func (k *PubKey) MultibaseString() string {
 		return "<invalid key type>"
 	}
 
-	var kb []byte
-	switch k.Type {
-	case KeyTypeEd25519:
-		kb = []byte(k.Raw.(ed25519.PublicKey))
-	case KeyTypeP256:
-		pk := k.Raw.(*ecdsa.PublicKey)
-		if !pk.Curve.IsOnCurve(pk.X, pk.Y) {
-			return "<invalid key>"
-		}
-		kb = elliptic.MarshalCompressed(pk.Curve, pk.X, pk.Y)
-	case KeyTypeSecp256k1:
-		pk := k.Raw.(*secpEc.PublicKey)
-		p := pk.Point()
-		if p.IsIdentity() != 0 {
-			return "<invalid key>"
-		}
-		kb = p.CompressedBytes()
+	kb := k.rawBytes()
+	if kb == nil {
+		return "<invalid key>"
 	}
+
 	buf := varEncode(prefix, kb)
 
 	kstr, err := multibase.Encode(multibase.Base58BTC, buf)
@@ -258,6 +245,28 @@ func (k *PubKey) MultibaseString() string {
 		panic(err)
 	}
 	return kstr
+}
+
+func (k *PubKey) rawBytes() []byte {
+	switch k.Type {
+	case KeyTypeEd25519:
+		return []byte(k.Raw.(ed25519.PublicKey))
+	case KeyTypeP256:
+		pk := k.Raw.(*ecdsa.PublicKey)
+		if !pk.Curve.IsOnCurve(pk.X, pk.Y) {
+			return nil
+		}
+		return elliptic.MarshalCompressed(pk.Curve, pk.X, pk.Y)
+	case KeyTypeSecp256k1:
+		pk := k.Raw.(*secpEc.PublicKey)
+		p := pk.Point()
+		if p.IsIdentity() != 0 {
+			return nil
+		}
+		return p.CompressedBytes()
+	default:
+		return nil
+	}
 }
 
 func (k *PubKey) Verify(msg, sig []byte) error {
@@ -357,10 +366,13 @@ func PubKeyFromMultibaseString(s string) (*PubKey, error) {
 		return nil, fmt.Errorf("invalid key multicodec prefix: %x", prefix)
 	}
 
+	return keyDataAndTypeToKey(kt, raw)
+}
+
+func keyDataAndTypeToKey(kt string, raw []byte) (*PubKey, error) {
 	pk := &PubKey{
 		Type: kt,
 	}
-
 	// Convert from the binary encoding of the compressed point,
 	// to the actual concrete public key type.
 	switch kt {
@@ -376,14 +388,14 @@ func PubKeyFromMultibaseString(s string) (*PubKey, error) {
 		// secpEc.NewPublicKey accepts any valid encoding, while we
 		// explicitly want compressed, so use the explicit point
 		// decompression routine.
-		p, err := secp.NewIdentityPoint().SetCompressedBytes(raw)
+		p, err := secp.NewIdentityPoint().SetBytes(raw)
 		if err != nil {
-			return nil, fmt.Errorf("invalid k256 public key: %w", err)
+			return nil, fmt.Errorf("invalid k256 public key (setBytes): %w", err)
 		}
 
 		pub, err := secpEc.NewPublicKeyFromPoint(p)
 		if err != nil {
-			return nil, fmt.Errorf("invalid k256 public key: %w", err)
+			return nil, fmt.Errorf("invalid k256 public key (keyFromPt): %w", err)
 		}
 		pk.Raw = pub
 	case KeyTypeP256:

--- a/key.go
+++ b/key.go
@@ -28,6 +28,7 @@ const (
 	KeyTypeSecp256k1 = "EcdsaSecp256k1VerificationKey2019"
 	KeyTypeP256      = "EcdsaSecp256r1VerificationKey2019"
 	KeyTypeEd25519   = "Ed25519VerificationKey2020"
+	KeyTypeMultikey  = "Multikey"
 
 	didKeyPrefix = "did:key:"
 )

--- a/key_test.go
+++ b/key_test.go
@@ -79,10 +79,11 @@ func TestKey(t *testing.T) {
 				}
 
 				// Roundtrip Multibase VM encoding.
-				vm := VerificationMethod{
-					Type:               keyType,
-					PublicKeyMultibase: &pkStr,
+				vm, err := VerificationMethodFromKey(pk)
+				if err != nil {
+					t.Fatal(err)
 				}
+
 				pk3, err := vm.GetPublicKey()
 				if err != nil {
 					t.Fatal(err)

--- a/testdata/did_doc_legacy.json
+++ b/testdata/did_doc_legacy.json
@@ -1,0 +1,25 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/secp256k1-2019/v1"
+  ],
+  "id": "did:plc:yk4dd2qkboz2yv6tpubpc6co",
+  "alsoKnownAs": [
+    "at://dholms.xyz"
+  ],
+  "verificationMethod": [
+    {
+      "id": "#atproto",
+      "type": "EcdsaSecp256k1VerificationKey2019",
+      "controller": "did:plc:yk4dd2qkboz2yv6tpubpc6co",
+      "publicKeyMultibase": "zQYEBzXeuTM9UR3rfvNag6L3RNAs5pQZyYPsomTsgQhsxLdEgCrPTLgFna8yqCnxPpNT7DBk6Ym3dgPKNu86vt9GR"
+    }
+  ],
+  "service": [
+    {
+      "id": "#atproto_pds",
+      "type": "AtprotoPersonalDataServer",
+      "serviceEndpoint": "https://bsky.social"
+    }
+  ]
+}

--- a/testdata/did_doc_multikey.json
+++ b/testdata/did_doc_multikey.json
@@ -1,0 +1,26 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/multikey/v1",
+    "https://w3id.org/security/suites/secp256k1-2019/v1"
+  ],
+  "id": "did:plc:yk4dd2qkboz2yv6tpubpc6co",
+  "alsoKnownAs": [
+    "at://dholms.xyz"
+  ],
+  "verificationMethod": [
+    {
+      "id": "did:plc:yk4dd2qkboz2yv6tpubpc6co#atproto",
+      "type": "Multikey",
+      "controller": "did:plc:yk4dd2qkboz2yv6tpubpc6co",
+      "publicKeyMultibase": "zQ3shXjHeiBuRCKmM36cuYnm7YEMzhGnCmCyW92sRJ9pribSF"
+    }
+  ],
+  "service": [
+    {
+      "id": "#atproto_pds",
+      "type": "AtprotoPersonalDataServer",
+      "serviceEndpoint": "https://bsky.social"
+    }
+  ]
+}


### PR DESCRIPTION
There are a few things moving around, so some background context:

- this branch includes PR https://github.com/whyrusleeping/go-did/pull/10, which is what indigo has merged in and is running in bluesky services today, but never got merged to master
- it also includes https://github.com/whyrusleeping/go-did/pull/11, which got merged to go-did master, but I don't think has gotten pulled in to indigo
- we are in the process of changing/fixing how DID Documents are rendered to use multibase in the more expected format: "compact bytes" for P-256 and K-256 key types, and with multicodec indicator; and to use `Multikey` as the type for both key formats, relying on multicodec to disambiguate (a new DID specification feature); and to properly include the full DID plus a fragment in verificationMethod `id` fields (but not in service fields, where they are not required). this is the same issue that recently tripped up why. in the transition we need to support both DID Document formats
- we also have a new `atproto/crypto` package that we'll probably switch over to soon, which includes support for everything, and simpler API, and tests and docs https://github.com/bluesky-social/indigo/pull/270

This PR tries to get the exiting go-did implementation in a working state for the new DID document changes. It adds real-life DID documents as minimal test coverage.

cc: @whyrusleeping 